### PR TITLE
speedは-1もありえる

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -26,7 +26,12 @@ export default function HomeScreen() {
       entry.samples.push({
         ts: a.timestamp,
         accuracyM: a.coords.accuracy,
-        speedKmh: a.coords.speed != null ? a.coords.speed * 3.6 : undefined,
+        speedKmh:
+          a.coords.speed === -1
+            ? undefined
+            : a.coords.speed != null
+            ? a.coords.speed * 3.6
+            : undefined,
       });
       byId.set(a.id, entry);
     }

--- a/components/ActivityCell.tsx
+++ b/components/ActivityCell.tsx
@@ -88,7 +88,7 @@ export function ActivityCell({ item }: Props) {
 
   const speedKMH = useMemo(() => {
     const s = item.coords.speed;
-    if (s == null || Number.isNaN(s)) return null;
+    if (s == null || Number.isNaN(s) || s === -1) return null;
     return s * 3.6;
   }, [item.coords.speed]);
 

--- a/domain/received.ts
+++ b/domain/received.ts
@@ -15,7 +15,7 @@ const LocationUpdateDataSchema = z.object({
     accuracy: z.number().min(0).optional(),
     latitude: z.number().min(-90).max(90),
     longitude: z.number().min(-180).max(180),
-    speed: z.number().min(0).optional(),
+    speed: z.number().optional(),
   }),
   device: z.string(),
   id: z.string(),

--- a/domain/received.ts
+++ b/domain/received.ts
@@ -15,7 +15,9 @@ const LocationUpdateDataSchema = z.object({
     accuracy: z.number().min(0).optional(),
     latitude: z.number().min(-90).max(90),
     longitude: z.number().min(-180).max(180),
-    speed: z.number().optional(),
+    speed: z
+      .union([z.number().finite().nonnegative(), z.literal(-1)])
+      .nullable(),
   }),
   device: z.string(),
   id: z.string(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 位置情報の「速度」値に対する受け入れ範囲を拡張し、null、-1、または非負の有限数を許可。欠落を許さない仕様に変更。
  - 多様な端末・OSからの速度データを安定して処理できるようになり、更新失敗やエラー表示が減少、追跡の継続性と信頼性が向上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->